### PR TITLE
vim: Add OS specific settings

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -1,6 +1,6 @@
 so ~/git/dotfiles/vim/common.vim
 so ~/git/dotfiles/vim/clipboard.vim
-so ~/git/dotfiles/vim/linux.vim
+so ~/git/dotfiles/vim/os.vim
 so ~/git/dotfiles/vim/indents.vim
 so ~/git/dotfiles/vim/colorcolumn80.vim
 

--- a/vim/linux.vim
+++ b/vim/linux.vim
@@ -1,5 +1,0 @@
-packadd termdebug
-
-set backupdir=/tmp//
-set directory=/tmp//
-set undodir=/tmp//

--- a/vim/os.vim
+++ b/vim/os.vim
@@ -1,0 +1,11 @@
+if has('win32') || has('win64')
+    set backupdir=%TEMP%//
+    set directory=%TEMP%//
+    set undodir=%TEMP%//
+else 
+    packadd termdebug
+
+    set backupdir=/tmp//
+    set directory=/tmp//
+    set undodir=/tmp//
+endif


### PR DESCRIPTION
- Rename existing `linux.vim` to `os.vim`, switch between Windows and Linux